### PR TITLE
Fix missing std::tr1::hash on GCC 4.1 (option 2)

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -1726,17 +1726,10 @@ struct hash<google::protobuf::MapKey> {
         break;
       case google::protobuf::FieldDescriptor::CPPTYPE_STRING:
         return hash<string>()(map_key.GetStringValue());
-#if defined(GOOGLE_PROTOBUF_HAVE_64BIT_HASH)
       case google::protobuf::FieldDescriptor::CPPTYPE_INT64:
         return hash< ::google::protobuf::int64>()(map_key.GetInt64Value());
       case google::protobuf::FieldDescriptor::CPPTYPE_UINT64:
         return hash< ::google::protobuf::uint64>()(map_key.GetUInt64Value());
-#else
-      case google::protobuf::FieldDescriptor::CPPTYPE_INT64:
-      case google::protobuf::FieldDescriptor::CPPTYPE_UINT64:
-        GOOGLE_LOG(FATAL) << "Unsupported on this platform.";
-        break;
-#endif
       case google::protobuf::FieldDescriptor::CPPTYPE_INT32:
         return hash< ::google::protobuf::int32>()(map_key.GetInt32Value());
       case google::protobuf::FieldDescriptor::CPPTYPE_UINT32:

--- a/src/google/protobuf/stubs/hash.h
+++ b/src/google/protobuf/stubs/hash.h
@@ -40,7 +40,6 @@
 
 #define GOOGLE_PROTOBUF_HAVE_HASH_MAP 1
 #define GOOGLE_PROTOBUF_HAVE_HASH_SET 1
-#define GOOGLE_PROTOBUF_HAVE_64BIT_HASH 1
 
 // Use C++11 unordered_{map|set} if available.
 #if ((_LIBCPP_STD_VER >= 11) || \
@@ -93,9 +92,25 @@
 #  define GOOGLE_PROTOBUF_HASH_SET_CLASS hash_set
 # endif
 
+// GCC 4.1 and previous does not define hash for int64/uint64
 # if __GNUC__ == 4 && __GNUC__MINOR__ <= 1
-#  undef GOOGLE_PROTOBUF_HAVE_64BIT_HASH
-# endif
+#  include <tr1/functional>
+    namespace std {
+    namespace tr1 {
+
+    template<>
+    struct hash<long long int> {
+      std::size_t operator()(long long int val) const { return static_cast<std::size_t>(val); }
+    };
+
+    template<>
+    struct hash<long long unsigned int> {
+      std::size_t operator()(long long unsigned int val) const { return static_cast<std::size_t>(val); }
+    };
+
+    }  // namespace tr1
+    }  // namespace std
+# endif  // GCC <= 4.1
 
 // Version checks for MSC.
 // Apparently Microsoft decided to move hash_map *back* to the std namespace in

--- a/src/google/protobuf/stubs/hash.h
+++ b/src/google/protobuf/stubs/hash.h
@@ -99,13 +99,13 @@
     namespace tr1 {
 
     template<>
-    struct hash<long long int> {
-      std::size_t operator()(long long int val) const { return static_cast<std::size_t>(val); }
+    struct hash<google::protobuf::uint64> {
+      std::size_t operator()(google::protobuf::uint64 val) const { return static_cast<std::size_t>(val); }
     };
 
     template<>
-    struct hash<long long unsigned int> {
-      std::size_t operator()(long long unsigned int val) const { return static_cast<std::size_t>(val); }
+    struct hash<google::protobuf::int64> {
+      std::size_t operator()(google::protobuf::int64 val) const { return static_cast<std::size_t>(val); }
     };
 
     }  // namespace tr1


### PR DESCRIPTION
Rather than crashing on use (doh!) better to just implement the missing
std::tr1::hash structs.

Fixes regression introduced by #1913